### PR TITLE
change method of comparison

### DIFF
--- a/src/main/java/net/darkhax/oldjava/OldJavaWarning.java
+++ b/src/main/java/net/darkhax/oldjava/OldJavaWarning.java
@@ -47,7 +47,7 @@ public class OldJavaWarning {
         }
         
         // Warn users about using older versions of Java.
-        if (Config.warnVersion && Config.minVersion.compareTo(System.getProperty("java.version")) > 0) {
+        if (Config.warnVersion && Integer.parseInt(Config.minVersion.split("_")[1])>Integer.parseInt(System.getProperty("java.version").split("_")[1])) {
 
             displayWarning(I18n.format("oldjava.notice.update.body"), I18n.format("oldjava.notice.update.title"), I18n.format("oldjava.url.updateinfo"));
         }

--- a/src/main/java/net/darkhax/oldjava/OldJavaWarning.java
+++ b/src/main/java/net/darkhax/oldjava/OldJavaWarning.java
@@ -47,10 +47,15 @@ public class OldJavaWarning {
         }
         
         // Warn users about using older versions of Java.
-        if (Config.warnVersion && Integer.parseInt(Config.minVersion.split("_")[1])>Integer.parseInt(System.getProperty("java.version").split("_")[1])) {
+        String[] VersionConfig = Config.minVersion.split("_");
+        String[] VersionSystem = System.getProperty("java.version").split("_");
 
-            displayWarning(I18n.format("oldjava.notice.update.body"), I18n.format("oldjava.notice.update.title"), I18n.format("oldjava.url.updateinfo"));
-        }
+        if(VersionConfig.length>1 && VersionSystem.length>1)
+            if(VersionConfig[1].matches("[0-9]+") && VersionSystem[1].matches("[0-9]+"))
+                if (Config.warnVersion && Integer.parseInt(Config.minVersion.split("_")[1])>Integer.parseInt(System.getProperty("java.version").split("_")[1]))
+                    displayWarning(I18n.format("oldjava.notice.update.body"), I18n.format("oldjava.notice.update.title"), I18n.format("oldjava.url.updateinfo"));
+
+
     }
     
     private static void displayWarning(String message, String title, String url) {


### PR DESCRIPTION
I notice that when you use CurseForge with a java version 51, it never triggers the message about a old java
What happens is that the version printed is 1.8.0_51, when you compare with 1.8.0_162, it will tell you the 51 is higher than 162
So i splited the version into a array, and converted the second value to integer in order to do a better check

~~as a note
it will crash the game if the format isnt correct, aka missing the "_"
it will crash the game if the format isnt correct, aka if the "version" isnt a number~~

~~those 2 can be prevented with some more modifications~~